### PR TITLE
Update pulumi/pulumi-terraform to 8c7d415

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -522,7 +522,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "48b52f432aee94c78e4519e064b0400965a4f3d7"
+  revision = "8c7d4154b4c9bed966f720e4e10941d1d391b2a9"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
This pulls in the changes made in pulumi/pulumi-terraform#284. There are no changes to code generation as the changes are purely in the Terraform bridge.

Fixes pulumi/pulumi-terraform#281, and I have verified locally that the examples are passing.