### PR TITLE
Update pulumi-terraform@b84264ecec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openzipkin/zipkin-go v0.1.6 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pulumi/pulumi v1.0.0-beta.2
-	github.com/pulumi/pulumi-terraform v0.18.4-0.20190809001837-9db2fc93cdf5
+	github.com/pulumi/pulumi-terraform v0.18.4-0.20190823211354-b84264ecece6
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
 	github.com/terraform-providers/terraform-provider-random v0.0.0-20190808172436-0ce299bbf59e
 	golang.org/x/build v0.0.0-20190314133821-5284462c4bec // indirect

--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,8 @@ github.com/pulumi/pulumi-terraform v0.18.4-0.20190805204638-013b95b1c891 h1:mPKG
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190805204638-013b95b1c891/go.mod h1:HVA/Fkv+5PvaVY7LaBARUq1fzprob6GMLUgPZyHUXSs=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190809001837-9db2fc93cdf5 h1:k34JNaNxiwGF8ev6F9gAyZPwgMSDNCSqeofS2XMmFsM=
 github.com/pulumi/pulumi-terraform v0.18.4-0.20190809001837-9db2fc93cdf5/go.mod h1:/rpxRQe8RtRHrrmgmCXHA/9bSj7qxL2NvjmHCDfK77U=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190823211354-b84264ecece6 h1:tGHda0UyBXoNUys22i0PLwMriN9YynN5t0gGc3lQMW0=
+github.com/pulumi/pulumi-terraform v0.18.4-0.20190823211354-b84264ecece6/go.mod h1:/rpxRQe8RtRHrrmgmCXHA/9bSj7qxL2NvjmHCDfK77U=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=

--- a/resources.go
+++ b/resources.go
@@ -75,7 +75,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		Python: &tfbridge.PythonInfo{
 			Requires: map[string]string{
-				"pulumi": ">=0.17.28,<2.0.0",
+				"pulumi": ">=1.0.0b4,<1.0.1",
 			},
 		},
 	}

--- a/sdk/python/pulumi_random/provider.py
+++ b/sdk/python/pulumi_random/provider.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class Provider(pulumi.ProviderResource):
@@ -55,7 +56,7 @@ class Provider(pulumi.ProviderResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/index.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         return Provider(resource_name, opts=opts, __props__=__props__)

--- a/sdk/python/pulumi_random/random_id.py
+++ b/sdk/python/pulumi_random/random_id.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomId(pulumi.CustomResource):
@@ -127,7 +128,7 @@ class RandomId(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/id.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["b64"] = b64

--- a/sdk/python/pulumi_random/random_integer.py
+++ b/sdk/python/pulumi_random/random_integer.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomInteger(pulumi.CustomResource):
@@ -101,7 +102,7 @@ class RandomInteger(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/integer.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["keepers"] = keepers

--- a/sdk/python/pulumi_random/random_password.py
+++ b/sdk/python/pulumi_random/random_password.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomPassword(pulumi.CustomResource):
@@ -81,7 +82,7 @@ class RandomPassword(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/password.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["keepers"] = keepers

--- a/sdk/python/pulumi_random/random_pet.py
+++ b/sdk/python/pulumi_random/random_pet.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomPet(pulumi.CustomResource):
@@ -92,7 +93,7 @@ class RandomPet(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/pet.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["keepers"] = keepers

--- a/sdk/python/pulumi_random/random_shuffle.py
+++ b/sdk/python/pulumi_random/random_shuffle.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomShuffle(pulumi.CustomResource):
@@ -102,7 +103,7 @@ class RandomShuffle(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/shuffle.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["inputs"] = inputs

--- a/sdk/python/pulumi_random/random_string.py
+++ b/sdk/python/pulumi_random/random_string.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomString(pulumi.CustomResource):
@@ -184,7 +185,7 @@ class RandomString(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/string.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["keepers"] = keepers

--- a/sdk/python/pulumi_random/random_uuid.py
+++ b/sdk/python/pulumi_random/random_uuid.py
@@ -6,6 +6,7 @@ import json
 import warnings
 import pulumi
 import pulumi.runtime
+from typing import Union
 from . import utilities, tables
 
 class RandomUuid(pulumi.CustomResource):
@@ -75,7 +76,7 @@ class RandomUuid(pulumi.CustomResource):
 
         > This content is derived from https://github.com/terraform-providers/terraform-provider-random/blob/master/website/docs/r/uuid.html.markdown.
         """
-        opts = pulumi.ResourceOptions(id=id) if opts is None else opts.merge(pulumi.ResourceOptions(id=id))
+        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = dict()
         __props__["keepers"] = keepers

--- a/sdk/python/pulumi_random/utilities.py
+++ b/sdk/python/pulumi_random/utilities.py
@@ -61,7 +61,13 @@ def get_version():
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.dev is not None:
+    if pep440_version.pre_tag == 'a':
+        prerelease = f"alpha.{pep440_version.pre}"
+    elif pep440_version.pre_tag == 'b':
+        prerelease = f"beta.{pep440_version.pre}"
+    elif pep440_version.pre_tag == 'rc':
+        prerelease = f"rc.{pep440_version.pre}"
+    elif pep440_version.dev is not None:
         prerelease = f"dev.{pep440_version.dev}"
 
     # The only significant difference between PEP440 and semver as it pertains to us is that PEP440 has explicit support

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -43,7 +43,7 @@ setup(name='pulumi_random',
       packages=find_packages(),
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=0.17.28,<2.0.0',
+          'pulumi>=1.0.0b4,<1.0.1',
           'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
@pgavlin this used the automation to update to the latest pulumi-terraform and then also addresses the version number constraint issue that I discovered.

My plan is once landing this change to take the `1.0.1a` package produced from master and install it and make sure the following issues are addressed:

1. We pull in 1.0.0b4 of pulumi
2. The correct plugin is loaded without an error.

If that's the case, I will make similar changes across all of our tfgen providers and cut new `beta.X` versions.  Might be over the course of the evincing.  I expect all changes to look more or less like this across all our other providers.