### PR TITLE
Upgrade to pf/v0.2.1 fixing issue with upgrading stacks with keepers property set

### DIFF
--- a/examples/simple/ts/index.ts
+++ b/examples/simple/ts/index.ts
@@ -20,3 +20,8 @@ export const randomString = new random.RandomString("string", { length: 32 }).re
 export const randomInteger = new random.RandomInteger("integer", { min: 128, max: 1024 }).result;
 export const randomUuid = new random.RandomUuid("uuid").result;
 export const randomPassword = new random.RandomPassword("password", { length: 32 }).result;
+
+export const randomPasswordWithKeepers = new random.RandomPassword("passwordWithKeepers", {
+    length: 32,
+    keepers: { pwdseed1: "pwdseed1" },
+}).result;

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,8 +3,8 @@ module github.com/pulumi/pulumi-random/provider/v4
 go 1.19
 
 require (
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.1.1-0.20230207204608-6dbd650bf8bb
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1-0.20230120143314-6ffb2faf051e
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.2.1
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.40.1-0.20230214142332-83bd1f2d3013
 	github.com/pulumi/pulumi/sdk/v3 v3.53.1
 	github.com/terraform-providers/terraform-provider-random/shim v0.0.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1482,10 +1482,10 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.7.1 h1:3tl36+I5BRYVXbq10mqDeh3X5kdJBaNDYiATOfEfgSY=
 github.com/pulumi/pulumi-java/pkg v0.7.1/go.mod h1:XdN2jYNlcQewr0MFecZfBnY3gnGcvV+WoPTzQqH48k4=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.1.1-0.20230207204608-6dbd650bf8bb h1:wfFdCd3g3mUr7bCGOAz0kKLsA01IyYt17x+Jup3xKoM=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.1.1-0.20230207204608-6dbd650bf8bb/go.mod h1:1z9JEISCnJUjLLAgc0rJG2yLk0IbiEgkwv076AUafYo=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1-0.20230120143314-6ffb2faf051e h1:+FRdpUEigEWHwquSO9VPNOWDMpyODWg5ek3roDXGA+g=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1-0.20230120143314-6ffb2faf051e/go.mod h1:Lp+GVsSZUMeS7vtyCE1ytBxXDdsXWe4RxMaFTvL973s=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.2.1 h1:SGR0Os3WYMAWtveEsNn1ty46JuGSqbm7J6U/pIaP0F4=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.2.1/go.mod h1:1z9JEISCnJUjLLAgc0rJG2yLk0IbiEgkwv076AUafYo=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.40.1-0.20230214142332-83bd1f2d3013 h1:autslRetGXxi3TF4htSupCEVcVe5ynIxtfSqLxNP/6o=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.40.1-0.20230214142332-83bd1f2d3013/go.mod h1:McH/PLanWyrObVQIPwwZAffK26hxNXQScjp6NyGibpo=
 github.com/pulumi/pulumi-yaml v1.0.4 h1:p+989rW3AqkkxbzxtxccHKAN4xCJi3K2cRpvA2K84tw=
 github.com/pulumi/pulumi-yaml v1.0.4/go.mod h1:Szj8ud4Vqyq3oO1n3kzIUfaP3AiCjYZM4FYjOVWwJn8=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1 h1:NSgzjci0ykEoKC2BHmp/brP7/V8ARafl8ovr76B9Jak=


### PR DESCRIPTION
Fixes issues with upgrading stacks with `keepers` property set to the latest version. The issue is caused by a bug in the Plugin Framework bridge (https://github.com/pulumi/pulumi-terraform-bridge/issues/810) that was addressed on the latest version `pf/v0.2.1`.