### PR TITLE
Embed version for all SDKs

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -36,7 +36,7 @@ worktreeAllowedChanges: |-
   sdk/dotnet/Pulumi.*.csproj
   sdk/go/random/internal/pulumiUtilities.go
   sdk/nodejs/package.json
-  sdk/python/*/pyproject.toml
+  sdk/python/pyproject.toml
 
 publish:
   goSdk:

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -29,3 +29,11 @@ actions:
       run: |
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
+
+worktreeAllowedChanges: |-
+  sdk/go/random/pulumi-plugin.json
+  sdk/go/random/internal/pulumiUtilities.go
+
+publish:
+  goSdk:
+    usePush: true

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -30,9 +30,13 @@ actions:
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 
+# These files are updated with the real version number
 worktreeAllowedChanges: |-
-  sdk/go/random/pulumi-plugin.json
+  sdk/**/pulumi-plugin.json
+  sdk/dotnet/Pulumi.*.csproj
   sdk/go/random/internal/pulumiUtilities.go
+  sdk/nodejs/package.json
+  sdk/python/*/pyproject.toml
 
 publish:
   goSdk:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -104,8 +104,11 @@ jobs:
       uses: pulumi/git-status-check-action@v1
       with:
         allowed-changes: |
-          sdk/go/random/pulumi-plugin.json
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
           sdk/go/random/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,6 +102,10 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/go/random/pulumi-plugin.json
+          sdk/go/random/internal/pulumiUtilities.go
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -105,8 +105,11 @@ jobs:
       uses: pulumi/git-status-check-action@v1
       with:
         allowed-changes: |
-          sdk/go/random/pulumi-plugin.json
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
           sdk/go/random/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -103,6 +103,10 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/go/random/pulumi-plugin.json
+          sdk/go/random/internal/pulumiUtilities.go
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,11 @@ jobs:
       uses: pulumi/git-status-check-action@v1
       with:
         allowed-changes: |
-          sdk/go/random/pulumi-plugin.json
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
           sdk/go/random/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,10 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/go/random/pulumi-plugin.json
+          sdk/go/random/internal/pulumiUtilities.go
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -359,9 +363,14 @@ jobs:
         repo: pulumi/pulumictl
     - id: version
       uses: pulumi/provider-version-action@v1
-    - name: Add SDK version tag
-      run: git tag "sdk/v${{ steps.version.outputs.version }}" && git push origin
-        "sdk/v${{ steps.version.outputs.version }}"
+    - uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
 
   clean_up_release_labels:
     name: Clean up release labels

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -112,6 +112,10 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/go/random/pulumi-plugin.json
+          sdk/go/random/internal/pulumiUtilities.go
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -114,8 +114,11 @@ jobs:
       uses: pulumi/git-status-check-action@v1
       with:
         allowed-changes: |
-          sdk/go/random/pulumi-plugin.json
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
           sdk/go/random/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider/cmd/pulumi-resource-random/schema.json
+++ b/provider/cmd/pulumi-resource-random/schema.json
@@ -25,7 +25,8 @@
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-random/sdk/v4/go/random",
             "generateResourceContainerTypes": true,
-            "generateExtraInputTypes": true
+            "generateExtraInputTypes": true,
+            "respectSchemaVersion": true
         },
         "nodejs": {
             "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",

--- a/provider/cmd/pulumi-resource-random/schema.json
+++ b/provider/cmd/pulumi-resource-random/schema.json
@@ -14,13 +14,11 @@
     },
     "language": {
         "csharp": {
-            "packageReferences": {
-                "Pulumi": "3.*"
-            },
             "namespaces": {
                 "random": "Random"
             },
-            "compatibility": "tfbridge20"
+            "compatibility": "tfbridge20",
+            "respectSchemaVersion": true
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-random/sdk/v4/go/random",
@@ -31,21 +29,14 @@
         "nodejs": {
             "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
-            "dependencies": {
-                "@pulumi/pulumi": "^3.0.0"
-            },
-            "devDependencies": {
-                "@types/node": "^10.0.0"
-            },
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true
+            "disableUnionOutputTypes": true,
+            "respectSchemaVersion": true
         },
         "python": {
-            "requires": {
-                "pulumi": "\u003e=3.0.0,\u003c4.0.0"
-            },
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
             "compatibility": "tfbridge20",
+            "respectSchemaVersion": true,
             "pyproject": {
                 "enabled": true
             }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -94,6 +94,7 @@ func Provider() tfbridge.ProviderInfo {
 		})(),
 
 		Golang: &tfbridge.GolangInfo{
+			RespectSchemaVersion: true,
 			ImportBasePath: filepath.Join(
 				fmt.Sprintf("github.com/pulumi/pulumi-%[1]s/sdk/", randomPkg),
 				tfbridge.GetModuleMajorVersion(version.Version),

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -77,24 +77,17 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
-			Dependencies: map[string]string{
-				"@pulumi/pulumi": "^3.0.0",
-			},
-			DevDependencies: map[string]string{
-				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.
-			},
+			RespectSchemaVersion: true,
 		},
 		Python: (func() *tfbridge.PythonInfo {
 			i := &tfbridge.PythonInfo{
-				Requires: map[string]string{
-					"pulumi": ">=3.0.0,<4.0.0",
-				}}
+				RespectSchemaVersion: true,
+			}
 			i.PyProject.Enabled = true
 			return i
 		})(),
 
 		Golang: &tfbridge.GolangInfo{
-			RespectSchemaVersion: true,
 			ImportBasePath: filepath.Join(
 				fmt.Sprintf("github.com/pulumi/pulumi-%[1]s/sdk/", randomPkg),
 				tfbridge.GetModuleMajorVersion(version.Version),
@@ -102,11 +95,10 @@ func Provider() tfbridge.ProviderInfo {
 				randomPkg,
 			),
 			GenerateResourceContainerTypes: true,
+			RespectSchemaVersion:           true,
 		},
 		CSharp: &tfbridge.CSharpInfo{
-			PackageReferences: map[string]string{
-				"Pulumi": "3.*",
-			},
+			RespectSchemaVersion: true,
 			Namespaces: map[string]string{
 				"random": "Random",
 			},

--- a/sdk/dotnet/Pulumi.Random.csproj
+++ b/sdk/dotnet/Pulumi.Random.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://pulumi.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-random</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>4.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -44,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "random"
+  "name": "random",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/go/random/internal/pulumiUtilities.go
+++ b/sdk/go/random/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/random/pulumi-plugin.json
+++ b/sdk/go/random/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "random"
+  "name": "random",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/random",
-    "version": "${VERSION}",
+    "version": "4.0.0-alpha.0+dev",
     "description": "A Pulumi package to safely use randomness in Pulumi programs.",
     "keywords": [
         "pulumi",
@@ -13,14 +13,15 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0"
+        "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^14",
         "typescript": "^4.3.5"
     },
     "pulumi": {
         "resource": true,
-        "name": "random"
+        "name": "random",
+        "version": "4.0.0-alpha.0+dev"
     }
 }

--- a/sdk/python/pulumi_random/pulumi-plugin.json
+++ b/sdk/python/pulumi_random/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "random"
+  "name": "random",
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
   name = "pulumi_random"
   description = "A Pulumi package to safely use randomness in Pulumi programs."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
   keywords = ["pulumi", "random"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "0.0.0"
+  version = "4.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
Part of for https://github.com/pulumi/home/issues/3372

## 1. Enable embedding version number in each language's SDK

```go
RespectSchemaVersion: true
```

## 2. Configure ci-mgmt

Versions are stable within the same major version for local development but will be updated during the build in CI.

```yaml
worktreeAllowedChanges: |-
  sdk/**/pulumi-plugin.json
  sdk/dotnet/Pulumi.*.csproj
  sdk/go/random/internal/pulumiUtilities.go
  sdk/nodejs/package.json
  sdk/python/*/pyproject.toml

publish:
  goSdk:
    usePush: true
```

## Extra: Remove explicit dependencies

Where possible, let the language decide what it needs.
