### PR TITLE
Remove verification for PyPi

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -32,6 +32,6 @@ pulumiConvert: 1
 registryDocs: true
 releaseVerification:
   nodejs: examples/simple/ts
-  python: examples/simple/py
+  # python: examples/simple/py # TODO[https://github.com/pulumi/verify-provider-release/issues/74]
   dotnet: examples/simple/csharp
   go: examples/simple/go

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -78,13 +78,6 @@ jobs:
           directory: examples/simple/ts
           provider: random
           providerVersion: ${{ inputs.providerVersion }}
-      - name: Verify python release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: python
-          directory: examples/simple/py
-          provider: random
-          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify dotnet release
         uses: pulumi/verify-provider-release@v1
         with:


### PR DESCRIPTION
pulumi/verify-provider-release#74 prevents us from correctly verifying the python release. This commit disables it until pulumi/verify-provider-release#74 can be resolved.

Fixes https://github.com/pulumi/pulumi-random/issues/1443