### PR TITLE
Remove verification for nodejs

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -31,7 +31,7 @@ actions:
 pulumiConvert: 1
 registryDocs: true
 releaseVerification:
-  nodejs: examples/simple/ts
+  # nodejs: examples/simple/ts # TODO[https://github.com/pulumi/verify-provider-release/issues/73]
   # python: examples/simple/py # TODO[https://github.com/pulumi/verify-provider-release/issues/74]
   dotnet: examples/simple/csharp
   go: examples/simple/go

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -71,13 +71,6 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - name: Verify nodejs release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: nodejs
-          directory: examples/simple/ts
-          provider: random
-          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify dotnet release
         uses: pulumi/verify-provider-release@v1
         with:


### PR DESCRIPTION
Verification can be restored when
https://github.com/pulumi/verify-provider-release/issues/73 is resolved.

Fixes https://github.com/pulumi/pulumi-random/issues/1445