### PR TITLE
Remove verification for nodejs

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -33,5 +33,5 @@ registryDocs: true
 releaseVerification:
   # nodejs: examples/simple/ts # TODO[https://github.com/pulumi/verify-provider-release/issues/73]
   # python: examples/simple/py # TODO[https://github.com/pulumi/verify-provider-release/issues/74]
-  dotnet: examples/simple/csharp
+  # dotnet: examples/simple/csharp # TODO[https://github.com/pulumi/verify-provider-release/issues/75]
   go: examples/simple/go

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -71,13 +71,6 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - name: Verify dotnet release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: dotnet
-          directory: examples/simple/csharp
-          provider: random
-          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify go release
         uses: pulumi/verify-provider-release@v1
         if: inputs.skipGoSdk == false


### PR DESCRIPTION
Verification can be restored when
https://github.com/pulumi/verify-provider-release/issues/75 is resolved.

Fixes https://github.com/pulumi/pulumi-random/issues/1447