### PR TITLE
Enable dotnet and nodejs verification

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -31,7 +31,7 @@ actions:
 pulumiConvert: 1
 registryDocs: true
 releaseVerification:
-  # nodejs: examples/simple/ts # TODO[https://github.com/pulumi/verify-provider-release/issues/73]
+  nodejs: examples/simple/ts
   python: examples/simple/py
-  # dotnet: examples/simple/csharp # TODO[https://github.com/pulumi/verify-provider-release/issues/75]
+  dotnet: examples/simple/csharp
   go: examples/simple/go

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -79,6 +79,13 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
+      - name: Verify nodejs release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: nodejs
+          directory: examples/simple/ts
+          provider: random
+          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify python release
         uses: pulumi/verify-provider-release@v1
         with:
@@ -87,6 +94,13 @@ jobs:
           provider: random
           providerVersion: ${{ inputs.providerVersion }}
           packageVersion: ${{ inputs.pythonVersion || inputs.providerVersion }}
+      - name: Verify dotnet release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: dotnet
+          directory: examples/simple/csharp
+          provider: random
+          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify go release
         uses: pulumi/verify-provider-release@v1
         if: inputs.skipGoSdk == false


### PR DESCRIPTION
Following releases to verify-provider-release, these should now be functional.

Manual verification run succeeded: https://github.com/pulumi/pulumi-random/actions/runs/12299185014