### PR TITLE
Remove `preTest` action as unit tests are run by default

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -1,16 +1,12 @@
 provider: random
 major-version: 4
 makeTemplate: bridged
-# TODO: Enable this once our random provider is updated with framework support
-# generate-nightly-test-workflow: true
 plugins:
   - name: std
     version: "1.6.2"
-
   - name: terraform
     version: "1.0.16"
     kind: converter
-
   - name: aws
     version: "6.32.0"
   - name: azure
@@ -19,12 +15,6 @@ team: ecosystem
 license:
   ignore:
     - github.com/terraform-providers/terraform-provider-random/shim
-
-actions:
-  preTest:
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 registryDocs: true
 releaseVerification:
@@ -32,3 +22,4 @@ releaseVerification:
   python: examples/simple/py
   dotnet: examples/simple/csharp
   go: examples/simple/go
+integrationTestProvider: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
     - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -79,9 +79,6 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - name: Run provider tests
-        run: |
-          cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@v1
         with:


### PR DESCRIPTION
The `actions.preTest` modifier is no longer necessary since `ci-mgmt` now runs unit tests in the `prerequisites` step. This change removes the redundancy caused by previously using `actions.preTest` to work around the lack of default unit test execution.

This is necessary now because ci-mgmt recently started running `actions.preTest` as part of release verification, and that job is not able to run `actions.preTest` step (missing `gotestfmt`).

Fixes https://github.com/pulumi/pulumi-random/issues/1537