### PR TITLE
enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -78,9 +78,6 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
-			Dependencies: map[string]string{
-				"@pulumi/pulumi": "^3.0.0",
-			},
 			DevDependencies: map[string]string{
 				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.
 			},
@@ -89,9 +86,6 @@ func Provider() tfbridge.ProviderInfo {
 		Python: (func() *tfbridge.PythonInfo {
 			i := &tfbridge.PythonInfo{
 				RespectSchemaVersion: true,
-				Requires: map[string]string{
-					"pulumi": ">=3.0.0,<4.0.0",
-				},
 			}
 			i.PyProject.Enabled = true
 			return i
@@ -116,6 +110,7 @@ func Provider() tfbridge.ProviderInfo {
 				"random": "Random",
 			},
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	makeToken := func(module, name string) (string, error) {


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-random provider. This should improve the quality of our previews for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598