### PR TITLE
Enable RawStateDelta

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -10,6 +10,7 @@ replace (
 )
 
 require (
+	github.com/pulumi/providertest v0.3.0
 	github.com/pulumi/pulumi-random/provider/v4 v4.0.0-20230306191832-8c7659ab0229
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.107.0
 	github.com/pulumi/pulumi/pkg/v3 v3.163.0

--- a/examples/regress_160_test.go
+++ b/examples/regress_160_test.go
@@ -17,7 +17,7 @@ package examples
 import (
 	"testing"
 
-	testutils "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/testing"
+	testutils "github.com/pulumi/providertest/replay"
 )
 
 // This makes sure that importing a random password works. The key method is Read.
@@ -57,6 +57,7 @@ func TestRegress160(t *testing.T) {
 	    "response": {
 	      "id": "none",
 	      "properties": {
+                "*": "*",
 		"__meta": "{\"schema_version\":\"3\"}",
 		"bcryptHash": {
 		  "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",

--- a/examples/regress_272_test.go
+++ b/examples/regress_272_test.go
@@ -17,7 +17,7 @@ package examples
 import (
 	"testing"
 
-	testutils "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/testing"
+	testutils "github.com/pulumi/providertest/replay"
 )
 
 func TestRegress272(t *testing.T) {
@@ -105,7 +105,7 @@ func TestRegress272(t *testing.T) {
 	  "response": {
 	    "id": "*",
 	    "properties": {
-	      "__meta": "*",
+              "*": "*",
 	      "id": "*",
 	      "length": 6,
 	      "lower": true,

--- a/examples/regress_279_test.go
+++ b/examples/regress_279_test.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	testutils "github.com/pulumi/providertest/replay"
 	provider "github.com/pulumi/pulumi-random/provider/v4"
 	"github.com/pulumi/pulumi-random/provider/v4/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
-	testutils "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )

--- a/examples/regress_393_test.go
+++ b/examples/regress_393_test.go
@@ -17,7 +17,7 @@ package examples
 import (
 	"testing"
 
-	testutils "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/testing"
+	testutils "github.com/pulumi/providertest/replay"
 )
 
 func TestRegress393(t *testing.T) {
@@ -35,6 +35,7 @@ func TestRegress393(t *testing.T) {
 		},
 		"response": {
 			"properties": {
+				"*": "*",
 				"bcryptHash": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
 				"id": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
 				"length": 256,
@@ -71,6 +72,7 @@ func TestRegress393(t *testing.T) {
 		"response": {
 			"id": "none",
 			"properties": {
+				"*": "*",
 				"__meta": "{\"schema_version\":\"3\"}",
 				"bcryptHash": "*",
 				"id": "none",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -113,6 +113,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		EnableAccurateBridgePreview: true,
+		EnableRawStateDelta:         true,
 	}
 
 	makeToken := func(module, name string) (string, error) {


### PR DESCRIPTION
An experimental bridged feature for preserving Terraform raw state is being rolled out to this provider. See also:

- https://github.com/pulumi/pulumi-terraform-bridge/issues/1667
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3003 

IN addition to this change, `github.com/pulumi/providertest v0.3.0` is introduced to replace deprecated bridge package for replay tests, and the corresponding tests are made to ignore unknown properties so that the new meta-properties used by the RawStateDelta feature do not trip up the tests.